### PR TITLE
Add email templates for adding exising user to org

### DIFF
--- a/akvo/templates/registration/user_organisation_invited_message.txt
+++ b/akvo/templates/registration/user_organisation_invited_message.txt
@@ -1,0 +1,13 @@
+{% load i18n %}
+
+{% blocktrans with user_name=user.get_full_name org_name=organisation.long_name %}
+Dear {{user_name}},
+
+You have been added to organisation: {{org_name}}.
+
+Please visit the MyRSR section to view your projects and add updates to the projects here:
+http://{{ site }}/myrsr/
+
+Thank you,
+Akvo.org
+{% endblocktrans %}

--- a/akvo/templates/registration/user_organisation_invited_subject.txt
+++ b/akvo/templates/registration/user_organisation_invited_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{% blocktrans with user_name=user.get_full_name organisation_name=organisation.name %}[Akvo RSR] {{ user_name }}, you are now a part of {{ organisation_name }} on Akvo RSR!{% endblocktrans %}


### PR DESCRIPTION
This change adds email message and subject templates that are to be used when
adding/inviting an existing user to an organisation.
